### PR TITLE
Remove empty lines

### DIFF
--- a/grote/functions/load.py
+++ b/grote/functions/load.py
@@ -43,7 +43,9 @@ def check_and_parse_inputs_fn(
     if file_in is not None:
         with open(file_in.name) as f:
             sentences_txt = f.read()
-    sentences_txt = sentences_txt.split("\n")
+            # remove empty lines
+            sentences_txt = re.sub(r"\n+", "\n", sentences_txt)
+    sentences_txt = sentences_txt.strip().split("\n")
 
     if not all(" ||| " in s for s in sentences_txt):
         raise gr.Error("ERROR: Sentences must match the format SOURCE ||| TARGET")


### PR DESCRIPTION
Should resolve #2. Just briefly tested on:
```
minor word aaaa ||| <minor>minor word</minor> translation


next sentence ||| next sentence

```

which correctly yields two sentences:
![image](https://github.com/gsarti/grote/assets/7661193/44a2a511-4d3b-4cd4-b154-65a096d6255d)


@gsarti do you have a specific case where you got errors?