### PR TITLE
Prevent accidental reload

### DIFF
--- a/grote/app.py
+++ b/grote/app.py
@@ -11,11 +11,19 @@ event_logger = EventLogger(
     cfg.hf_token, cfg.event_logs_hf_dataset_id, private=True, logging_dir=cfg.event_logs_local_dir
 )
 
+# launch default browser dialog when the window is refreshed/closed
+prevent_data_loss_js = """
+function prevent_reload() {
+    window.onbeforeunload = () => true;
+}
+"""
 
 def make_demo():
     with gr.Blocks(
         theme=gr.themes.Default(primary_hue="red", secondary_hue="pink"),
-        css=custom_css,  # js=ensure_dark_theme_js
+        css=custom_css,
+        js=prevent_data_loss_js,
+        # js=ensure_dark_theme_js
     ) as demo:
         gr.HTML('<img src="file/assets/img/grote_logo.png" width=200px />')
         lc = LoadComponents.build()


### PR DESCRIPTION
As discussed, this fires the default event for when the user is trying to leave the page.

![image](https://github.com/gsarti/grote/assets/7661193/fff7fd64-7168-44d4-9af8-2284b4d5eb77)

To my knowledge, this does not interfere with the rest of the app because there is no navigation/reloading during the annotation process. If we want, we can remove the dialogue after the user downloads the translation with:

```
window.onbeforeunload = null;
```

but I'd personally keep it, since they might post-editit more or something.